### PR TITLE
Fixing issue with displaying images.

### DIFF
--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -29,12 +29,7 @@ server {
     root /opt/app/dokuwiki;
     index doku.php;
     location ~ /(data/|conf/|bin/|inc/|install.php) { deny all; }
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-        expires 31536000s;
-        add_header Pragma "public";
-        add_header Cache-Control "max-age=31536000, public, must-revalidate, proxy-revalidate";
-        log_not_found off;
-    }
+    
     location / {
         try_files \$uri \$uri/ @dokuwiki;
     }


### PR DESCRIPTION
This commit fixes the problem with Dokuwiki displaying images. Apparently there is some conflict with the image rules and the rewrite rules below it. There is some documentation regarding this at [the Dokuwiki site](https://www.dokuwiki.org/install:nginx).

This commit simply removes the rules adding cache headers. It may be possible to fix this in a better way.

See also:
- https://forum.dokuwiki.org/thread/14008;?unb855sess=eaetsab7dssghenu4eb8ksq367
- https://groups.google.com/forum/#!msg/sandstorm-dev/Qe8K3sw2Fko/iIojWmEdCAAJ
